### PR TITLE
Fix helper systems download behavior

### DIFF
--- a/components/sections/helper-systems-section.tsx
+++ b/components/sections/helper-systems-section.tsx
@@ -105,6 +105,7 @@ function HelperSystemCard({ system, index }: HelperSystemCardProps) {
       const link = document.createElement("a")
       link.href = system.downloadUrl
       link.download = system.name
+      link.target = "_blank"
       document.body.appendChild(link)
       link.click()
       document.body.removeChild(link)


### PR DESCRIPTION
## Summary
- ensure download buttons in the homepage helper systems section open the file in a new tab

## Testing
- `npm run lint` *(fails: interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_686bd7a3b274832e81734d181872786f