### PR TITLE
Update local font setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+# fonts
+public/fonts/*.woff2

--- a/app/globals.css
+++ b/app/globals.css
@@ -84,7 +84,7 @@ body {
 
 body.rtl {
   direction: rtl;
-  font-family: var(--font-tajawal), sans-serif;
+  font-family: var(--font-cairo), sans-serif;
   text-align: right;
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { Tajawal, Roboto } from "next/font/google"
+import localFont from "next/font/local"
 import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { LanguageProvider } from "@/components/language-provider"
@@ -17,16 +17,27 @@ export const metadata = {
 // Add this function to improve page loading performance
 export const dynamic = "force-dynamic"
 
-const tajawal = Tajawal({
-  subsets: ["arabic"],
-  weight: ["400", "500", "700"],
-  variable: "--font-tajawal",
+const cairo = localFont({
+  src: [
+    { path: "../public/fonts/Cairo-300.woff2", weight: "300", style: "normal" },
+    { path: "../public/fonts/Cairo-400.woff2", weight: "400", style: "normal" },
+    { path: "../public/fonts/Cairo-700.woff2", weight: "700", style: "normal" },
+  ],
+  variable: "--font-cairo",
+  display: "swap",
 })
 
-const roboto = Roboto({
-  subsets: ["latin"],
-  weight: ["400", "500", "700"],
+const roboto = localFont({
+  src: [
+    { path: "../public/fonts/Roboto-300.woff2", weight: "300", style: "normal" },
+    { path: "../public/fonts/Roboto-300-italic.woff2", weight: "300", style: "italic" },
+    { path: "../public/fonts/Roboto-400.woff2", weight: "400", style: "normal" },
+    { path: "../public/fonts/Roboto-400-italic.woff2", weight: "400", style: "italic" },
+    { path: "../public/fonts/Roboto-700.woff2", weight: "700", style: "normal" },
+    { path: "../public/fonts/Roboto-700-italic.woff2", weight: "700", style: "italic" },
+  ],
   variable: "--font-roboto",
+  display: "swap",
 })
 
 export default function RootLayout({
@@ -40,7 +51,7 @@ export default function RootLayout({
         <title>بوابة الأمن السيبراني | Cybersecurity Portal</title>
         <meta name="description" content="أحدث المستجدات والتحليلات حول التهديدات السيبرانية وتقنيات الحماية" />
       </head>
-      <body className={`${tajawal.variable} ${roboto.variable}`}>
+      <body className={`${cairo.variable} ${roboto.variable}`}>
         <LanguageProvider>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <ErrorBoundary>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import localFont from "next/font/local"
+import { cairo, roboto } from "@/lib/fonts"
 import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { LanguageProvider } from "@/components/language-provider"
@@ -16,29 +16,6 @@ export const metadata = {
 
 // Add this function to improve page loading performance
 export const dynamic = "force-dynamic"
-
-const cairo = localFont({
-  src: [
-    { path: "../public/fonts/Cairo-300.woff2", weight: "300", style: "normal" },
-    { path: "../public/fonts/Cairo-400.woff2", weight: "400", style: "normal" },
-    { path: "../public/fonts/Cairo-700.woff2", weight: "700", style: "normal" },
-  ],
-  variable: "--font-cairo",
-  display: "swap",
-})
-
-const roboto = localFont({
-  src: [
-    { path: "../public/fonts/Roboto-300.woff2", weight: "300", style: "normal" },
-    { path: "../public/fonts/Roboto-300-italic.woff2", weight: "300", style: "italic" },
-    { path: "../public/fonts/Roboto-400.woff2", weight: "400", style: "normal" },
-    { path: "../public/fonts/Roboto-400-italic.woff2", weight: "400", style: "italic" },
-    { path: "../public/fonts/Roboto-700.woff2", weight: "700", style: "normal" },
-    { path: "../public/fonts/Roboto-700-italic.woff2", weight: "700", style: "italic" },
-  ],
-  variable: "--font-roboto",
-  display: "swap",
-})
 
 export default function RootLayout({
   children,

--- a/components/language-provider.tsx
+++ b/components/language-provider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, type ReactNode, useEffect } from "react"
 import { getTranslation, getDirection, type Language, type TranslationKey } from "@/lib/i18n"
+import { getFontFamily } from "@/lib/fonts"
 
 interface LanguageContextType {
   language: Language
@@ -49,11 +50,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     document.body.classList.toggle("ltr", !isRtl)
 
     // Update font family based on language
-    if (isRtl) {
-      document.body.style.fontFamily = "var(--font-cairo), sans-serif"
-    } else {
-      document.body.style.fontFamily = "var(--font-roboto), sans-serif"
-    }
+    document.body.style.fontFamily = getFontFamily(isRtl)
   }, [language, dir, isRtl, mounted])
 
   const t = (key: TranslationKey): string => {

--- a/components/language-provider.tsx
+++ b/components/language-provider.tsx
@@ -50,7 +50,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 
     // Update font family based on language
     if (isRtl) {
-      document.body.style.fontFamily = "var(--font-tajawal), sans-serif"
+      document.body.style.fontFamily = "var(--font-cairo), sans-serif"
     } else {
       document.body.style.fontFamily = "var(--font-roboto), sans-serif"
     }

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,0 +1,27 @@
+import localFont from "next/font/local"
+
+export const cairo = localFont({
+  src: [
+    { path: "../public/fonts/Cairo-300.woff2", weight: "300", style: "normal" },
+    { path: "../public/fonts/Cairo-400.woff2", weight: "400", style: "normal" },
+    { path: "../public/fonts/Cairo-700.woff2", weight: "700", style: "normal" },
+  ],
+  variable: "--font-cairo",
+  display: "swap",
+})
+
+export const roboto = localFont({
+  src: [
+    { path: "../public/fonts/Roboto-300.woff2", weight: "300", style: "normal" },
+    { path: "../public/fonts/Roboto-300-italic.woff2", weight: "300", style: "italic" },
+    { path: "../public/fonts/Roboto-400.woff2", weight: "400", style: "normal" },
+    { path: "../public/fonts/Roboto-400-italic.woff2", weight: "400", style: "italic" },
+    { path: "../public/fonts/Roboto-700.woff2", weight: "700", style: "normal" },
+    { path: "../public/fonts/Roboto-700-italic.woff2", weight: "700", style: "italic" },
+  ],
+  variable: "--font-roboto",
+  display: "swap",
+})
+
+export const getFontFamily = (isRtl: boolean) =>
+  isRtl ? "var(--font-cairo), sans-serif" : "var(--font-roboto), sans-serif"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,7 +68,7 @@ const config = {
         sm: "calc(var(--radius) - 4px)",
       },
       fontFamily: {
-        sans: ["var(--font-tajawal)", "sans-serif"],
+        sans: ["var(--font-cairo)", "var(--font-roboto)", "sans-serif"],
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary
- remove unused fontsource dependencies
- expect Cairo and Roboto font files to be provided in `public/fonts`

## Testing
- `npm run lint` *(fails: interactive prompt from `next lint`)*

------
https://chatgpt.com/codex/tasks/task_e_686cd52ad8ec832eb3d243c0c14b1898