### PR TITLE
Switch font config to TTF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+# fonts
+public/fonts/*.ttf

--- a/app/globals.css
+++ b/app/globals.css
@@ -84,7 +84,7 @@ body {
 
 body.rtl {
   direction: rtl;
-  font-family: var(--font-tajawal), sans-serif;
+  font-family: var(--font-cairo), sans-serif;
   text-align: right;
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { Tajawal, Roboto } from "next/font/google"
+import { cairo, roboto } from "@/lib/fonts"
 import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { LanguageProvider } from "@/components/language-provider"
@@ -17,18 +17,6 @@ export const metadata = {
 // Add this function to improve page loading performance
 export const dynamic = "force-dynamic"
 
-const tajawal = Tajawal({
-  subsets: ["arabic"],
-  weight: ["400", "500", "700"],
-  variable: "--font-tajawal",
-})
-
-const roboto = Roboto({
-  subsets: ["latin"],
-  weight: ["400", "500", "700"],
-  variable: "--font-roboto",
-})
-
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -40,7 +28,7 @@ export default function RootLayout({
         <title>بوابة الأمن السيبراني | Cybersecurity Portal</title>
         <meta name="description" content="أحدث المستجدات والتحليلات حول التهديدات السيبرانية وتقنيات الحماية" />
       </head>
-      <body className={`${tajawal.variable} ${roboto.variable}`}>
+      <body className={`${cairo.variable} ${roboto.variable}`}>
         <LanguageProvider>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <ErrorBoundary>

--- a/components/language-provider.tsx
+++ b/components/language-provider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, type ReactNode, useEffect } from "react"
 import { getTranslation, getDirection, type Language, type TranslationKey } from "@/lib/i18n"
+import { getFontFamily } from "@/lib/fonts"
 
 interface LanguageContextType {
   language: Language
@@ -49,11 +50,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     document.body.classList.toggle("ltr", !isRtl)
 
     // Update font family based on language
-    if (isRtl) {
-      document.body.style.fontFamily = "var(--font-tajawal), sans-serif"
-    } else {
-      document.body.style.fontFamily = "var(--font-roboto), sans-serif"
-    }
+    document.body.style.fontFamily = getFontFamily(isRtl)
   }, [language, dir, isRtl, mounted])
 
   const t = (key: TranslationKey): string => {

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,0 +1,28 @@
+import localFont from "next/font/local"
+
+export const cairo = localFont({
+  src: [
+    { path: "../public/fonts/Cairo-Light.ttf", weight: "300", style: "normal" },
+    { path: "../public/fonts/Cairo-Regular.ttf", weight: "400", style: "normal" },
+    { path: "../public/fonts/Cairo-Bold.ttf", weight: "700", style: "normal" },
+    { path: "../public/fonts/Cairo-Italic.ttf", weight: "400", style: "italic" },
+  ],
+  variable: "--font-cairo",
+  display: "swap",
+})
+
+export const roboto = localFont({
+  src: [
+    { path: "../public/fonts/Roboto-Light.ttf", weight: "300", style: "normal" },
+    { path: "../public/fonts/Roboto-LightItalic.ttf", weight: "300", style: "italic" },
+    { path: "../public/fonts/Roboto-Regular.ttf", weight: "400", style: "normal" },
+    { path: "../public/fonts/Roboto-Italic.ttf", weight: "400", style: "italic" },
+    { path: "../public/fonts/Roboto-Bold.ttf", weight: "700", style: "normal" },
+    { path: "../public/fonts/Roboto-BoldItalic.ttf", weight: "700", style: "italic" },
+  ],
+  variable: "--font-roboto",
+  display: "swap",
+})
+
+export const getFontFamily = (isRtl: boolean) =>
+  isRtl ? "var(--font-cairo), sans-serif" : "var(--font-roboto), sans-serif"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,7 +68,7 @@ const config = {
         sm: "calc(var(--radius) - 4px)",
       },
       fontFamily: {
-        sans: ["var(--font-tajawal)", "sans-serif"],
+        sans: ["var(--font-cairo)", "var(--font-roboto)", "sans-serif"],
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary
- configure local fonts to use `.ttf` files instead of `.woff2`
- ignore `.ttf` files in git so font binaries aren't committed

## Testing
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_686cd52ad8ec832eb3d243c0c14b1898