### PR TITLE
Add environment template and usage docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Base URL for your API, including /api path
+NEXT_PUBLIC_API_BASE_URL=https://your-backend.com/api
+
+# Optional: separate URL for the security procedures API
+NEXT_PUBLIC_PROCEDURES_API_BASE_URL=https://your-procedures.com/api

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Cybersecurity Portal (Next.js)
+
+This project is a Next.js v15 application for a cybersecurity news portal.
+
+## Prerequisites
+
+- Node.js 18 or later
+- npm (recommended) or pnpm
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+   (If you prefer `pnpm`, run `pnpm install`.)
+2. Copy `.env.example` to `.env` and update the values:
+   ```bash
+   cp .env.example .env
+   ```
+   Set `NEXT_PUBLIC_API_BASE_URL` to the URL of your backend API. Optionally set `NEXT_PUBLIC_PROCEDURES_API_BASE_URL`.
+
+## Development
+
+Start the development server with hot reloading:
+
+```bash
+npm run dev
+```
+
+## Building and Running
+
+To create a production build and start the server:
+
+```bash
+npm run build
+npm run start
+```
+
+This starts the Next.js server from the `.next` directory. When deploying to IIS you can run this server via [iisnode](https://github.com/Azure/iisnode) or behind a reverse proxy.
+
+## Static Export
+
+Next.js supports exporting to a purely static site by setting `output: 'export'` in `next.config.mjs`. Because this project uses many dynamic routes, you would also need to implement `generateStaticParams` for each dynamic page. Without those implementations the build will fail. If all dynamic routes are handled, running `npm run build` will generate an `out/` folder which can be hosted as static files.
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,8 +14,6 @@ export const metadata = {
     "أحدث المستجدات والتحليلات حول التهديدات السيبرانية وتقنيات الحماية",
 };
 
-// Add this function to improve page loading performance
-export const dynamic = "force-dynamic";
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
## Summary
- add a README with installation and build instructions
- provide `.env.example` for required environment variables
- allow tracking `.env.example` in gitignore
- remove the `force-dynamic` directive from the main layout

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fd1df9430832e9ed5d27a2877c63a