### PR TITLE
Fix standard navigation slugs

### DIFF
--- a/app/standards/[category]/[standard]/[control]/[safeguard]/[technique]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/[safeguard]/[technique]/page.tsx
@@ -66,7 +66,10 @@ function TechniquePageContent() {
         // First get the standard
         const allStandards = await standardsService.getAllStandards()
         const foundStandard = allStandards.find(
-          (s) => generateSlug(s.nameEn) === standardSlug || generateSlug(s.nameAr) === standardSlug,
+          (s) =>
+            generateSlug(s.nameEn) === standardSlug ||
+            generateSlug(s.nameAr) === standardSlug ||
+            s.id === standardSlug,
         )
 
         if (!foundStandard) {
@@ -80,7 +83,10 @@ function TechniquePageContent() {
         // Then get controls for this standard
         const controlsResponse = await standardsService.getControlsByStandardId(foundStandard.id, 1, 100)
         const foundControl = controlsResponse.data.find(
-          (c) => generateSlug(c.nameEn) === controlSlug || generateSlug(c.nameAr) === controlSlug,
+          (c) =>
+            generateSlug(c.nameEn) === controlSlug ||
+            generateSlug(c.nameAr) === controlSlug ||
+            c.id === controlSlug,
         )
 
         if (!foundControl) {
@@ -94,7 +100,10 @@ function TechniquePageContent() {
         // Then get safeguards for this control
         const safeguardsResponse = await standardsService.getSafeguardsByControlId(foundControl.id, 1, 100)
         const foundSafeguard = safeguardsResponse.data.find(
-          (s) => generateSlug(s.nameEn) === safeguardSlug || generateSlug(s.nameAr) === safeguardSlug,
+          (s) =>
+            generateSlug(s.nameEn) === safeguardSlug ||
+            generateSlug(s.nameAr) === safeguardSlug ||
+            s.id === safeguardSlug,
         )
 
         if (!foundSafeguard) {
@@ -108,7 +117,10 @@ function TechniquePageContent() {
         // Finally get techniques for this safeguard
         const techniquesResponse = await standardsService.getTechniquesBySafeguardId(foundSafeguard.id, 1, 100)
         const foundTechnique = techniquesResponse.data.find(
-          (t) => generateSlug(t.nameEn) === techniqueSlug || generateSlug(t.nameAr) === techniqueSlug,
+          (t) =>
+            generateSlug(t.nameEn) === techniqueSlug ||
+            generateSlug(t.nameAr) === techniqueSlug ||
+            t.id === techniqueSlug,
         )
 
         if (!foundTechnique) {

--- a/app/standards/[category]/[standard]/[control]/[safeguard]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/[safeguard]/page.tsx
@@ -72,7 +72,10 @@ function SafeguardPageContent() {
         // First get the standard
         const allStandards = await standardsService.getAllStandards()
         const foundStandard = allStandards.find(
-          (s) => generateSlug(s.nameEn) === standardSlug || generateSlug(s.nameAr) === standardSlug,
+          (s) =>
+            generateSlug(s.nameEn) === standardSlug ||
+            generateSlug(s.nameAr) === standardSlug ||
+            s.id === standardSlug,
         )
 
         if (!foundStandard) {
@@ -86,7 +89,10 @@ function SafeguardPageContent() {
         // Then get controls for this standard
         const controlsResponse = await standardsService.getControlsByStandardId(foundStandard.id, 1, 100)
         const foundControl = controlsResponse.data.find(
-          (c) => generateSlug(c.nameEn) === controlSlug || generateSlug(c.nameAr) === controlSlug,
+          (c) =>
+            generateSlug(c.nameEn) === controlSlug ||
+            generateSlug(c.nameAr) === controlSlug ||
+            c.id === controlSlug,
         )
 
         if (!foundControl) {
@@ -100,7 +106,10 @@ function SafeguardPageContent() {
         // Then get safeguards for this control
         const safeguardsResponse = await standardsService.getSafeguardsByControlId(foundControl.id, 1, 100)
         const foundSafeguard = safeguardsResponse.data.find(
-          (s) => generateSlug(s.nameEn) === safeguardSlug || generateSlug(s.nameAr) === safeguardSlug,
+          (s) =>
+            generateSlug(s.nameEn) === safeguardSlug ||
+            generateSlug(s.nameAr) === safeguardSlug ||
+            s.id === safeguardSlug,
         )
 
         if (!foundSafeguard) {

--- a/app/standards/[category]/[standard]/[control]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/page.tsx
@@ -72,7 +72,11 @@ function ControlPageContent() {
               ?.toLowerCase()
               .replace(/\s+/g, "-")
               .replace(/[^\w-]/g, "") || ""
-          return slugEn === standardSlug || slugAr === standardSlug
+          return (
+            slugEn === standardSlug ||
+            slugAr === standardSlug ||
+            s.id === standardSlug
+          )
         })
 
         if (!foundStandard) {
@@ -100,7 +104,11 @@ function ControlPageContent() {
               ?.toLowerCase()
               .replace(/\s+/g, "-")
               .replace(/[^\w-]/g, "") || ""
-          return slugEn === controlSlug || slugAr === controlSlug
+          return (
+            slugEn === controlSlug ||
+            slugAr === controlSlug ||
+            c.id === controlSlug
+          )
         })
 
         if (!foundControl) {

--- a/app/standards/[category]/[standard]/page.tsx
+++ b/app/standards/[category]/[standard]/page.tsx
@@ -65,7 +65,11 @@ function StandardPageContent() {
             .replace(/\s+/g, "-")
             .replace(/[^\w-]/g, "")
 
-          return slugEn === standardSlug || slugAr === standardSlug
+          return (
+            slugEn === standardSlug ||
+            slugAr === standardSlug ||
+            s.id === standardSlug
+          )
         })
 
         if (!foundStandard) {


### PR DESCRIPTION
## Summary
- use slug when linking to standard pages
- keep slugs when navigating to controls, safeguards and techniques

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726b6b9fdc832e906ec7af46a6b501