### PR TITLE
Fix slug lookup for standards

### DIFF
--- a/app/standards/[category]/[standard]/[control]/[safeguard]/[technique]/[implementation]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/[safeguard]/[technique]/[implementation]/page.tsx
@@ -9,7 +9,13 @@ import { ChevronLeft, Settings } from "lucide-react"
 import Link from "next/link"
 import { useLanguage } from "@/components/language-provider"
 import { container } from "@/core/di/container"
-import type { Control, Standard, Safeguard, Technique, ImplementationStep } from "@/core/domain/models/standard"
+import type {
+  Control,
+  Standard,
+  Safeguard,
+  Technique,
+  ImplementationStep,
+} from "@/core/domain/models/standard"
 
 export default function ImplementationStepPage() {
   return (
@@ -47,13 +53,6 @@ function ImplementationStepPageContent() {
   const [error, setError] = useState<string | null>(null)
 
   const standardsService = container.standardsService
-
-  const generateSlug = (text: string): string => {
-    return text
-      .toLowerCase()
-      .replace(/\s+/g, "-")
-      .replace(/[^\w-]/g, "")
-  }
 
   useEffect(() => {
     const fetchData = async () => {

--- a/app/standards/[category]/[standard]/[control]/[safeguard]/[technique]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/[safeguard]/[technique]/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link"
 import { useLanguage } from "@/components/language-provider"
 import { container } from "@/core/di/container"
 import type { Control, Standard, Safeguard, Technique, ImplementationStep } from "@/core/domain/models/standard"
+import { slugify } from "@/lib/utils"
 
 export default function TechniquePage() {
   return (
@@ -48,13 +49,6 @@ function TechniquePageContent() {
 
   const standardsService = container.standardsService
 
-  const generateSlug = (text: string): string => {
-    return text
-      .toLowerCase()
-      .replace(/\s+/g, "-")
-      .replace(/[^\w-]/g, "")
-  }
-
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -66,7 +60,10 @@ function TechniquePageContent() {
         // First get the standard
         const allStandards = await standardsService.getAllStandards()
         const foundStandard = allStandards.find(
-          (s) => generateSlug(s.nameEn) === standardSlug || generateSlug(s.nameAr) === standardSlug,
+          (s) =>
+            slugify(s.nameEn) === standardSlug ||
+            slugify(s.nameAr) === standardSlug ||
+            s.id === standardSlug,
         )
 
         if (!foundStandard) {
@@ -80,7 +77,10 @@ function TechniquePageContent() {
         // Then get controls for this standard
         const controlsResponse = await standardsService.getControlsByStandardId(foundStandard.id, 1, 100)
         const foundControl = controlsResponse.data.find(
-          (c) => generateSlug(c.nameEn) === controlSlug || generateSlug(c.nameAr) === controlSlug,
+          (c) =>
+            slugify(c.nameEn) === controlSlug ||
+            slugify(c.nameAr) === controlSlug ||
+            c.id === controlSlug,
         )
 
         if (!foundControl) {
@@ -94,7 +94,10 @@ function TechniquePageContent() {
         // Then get safeguards for this control
         const safeguardsResponse = await standardsService.getSafeguardsByControlId(foundControl.id, 1, 100)
         const foundSafeguard = safeguardsResponse.data.find(
-          (s) => generateSlug(s.nameEn) === safeguardSlug || generateSlug(s.nameAr) === safeguardSlug,
+          (s) =>
+            slugify(s.nameEn) === safeguardSlug ||
+            slugify(s.nameAr) === safeguardSlug ||
+            s.id === safeguardSlug,
         )
 
         if (!foundSafeguard) {
@@ -108,7 +111,10 @@ function TechniquePageContent() {
         // Finally get techniques for this safeguard
         const techniquesResponse = await standardsService.getTechniquesBySafeguardId(foundSafeguard.id, 1, 100)
         const foundTechnique = techniquesResponse.data.find(
-          (t) => generateSlug(t.nameEn) === techniqueSlug || generateSlug(t.nameAr) === techniqueSlug,
+          (t) =>
+            slugify(t.nameEn) === techniqueSlug ||
+            slugify(t.nameAr) === techniqueSlug ||
+            t.id === techniqueSlug,
         )
 
         if (!foundTechnique) {

--- a/app/standards/[category]/[standard]/[control]/[safeguard]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/[safeguard]/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link"
 import { useLanguage } from "@/components/language-provider"
 import { container } from "@/core/di/container"
 import type { Control, Standard, Safeguard, Technique } from "@/core/domain/models/standard"
+import { slugify } from "@/lib/utils"
 
 export default function SafeguardPage() {
   return (
@@ -47,15 +48,8 @@ function SafeguardPageContent() {
 
   const standardsService = container.standardsService
 
-  const generateSlug = (text: string): string => {
-    return text
-      .toLowerCase()
-      .replace(/\s+/g, "-")
-      .replace(/[^\w-]/g, "")
-  }
-
   const handleTechniqueClick = (technique: Technique) => {
-    const techniqueSlug = generateSlug(technique.nameEn || technique.nameAr)
+    const techniqueSlug = slugify(technique.nameEn || technique.nameAr)
     const url = `/standards/${category}/${standardSlug}/${controlSlug}/${safeguardSlug}/${techniqueSlug}`
     console.log("🔗 Navigating to technique:", url)
     window.location.href = url
@@ -72,7 +66,10 @@ function SafeguardPageContent() {
         // First get the standard
         const allStandards = await standardsService.getAllStandards()
         const foundStandard = allStandards.find(
-          (s) => generateSlug(s.nameEn) === standardSlug || generateSlug(s.nameAr) === standardSlug,
+          (s) =>
+            slugify(s.nameEn) === standardSlug ||
+            slugify(s.nameAr) === standardSlug ||
+            s.id === standardSlug,
         )
 
         if (!foundStandard) {
@@ -86,7 +83,10 @@ function SafeguardPageContent() {
         // Then get controls for this standard
         const controlsResponse = await standardsService.getControlsByStandardId(foundStandard.id, 1, 100)
         const foundControl = controlsResponse.data.find(
-          (c) => generateSlug(c.nameEn) === controlSlug || generateSlug(c.nameAr) === controlSlug,
+          (c) =>
+            slugify(c.nameEn) === controlSlug ||
+            slugify(c.nameAr) === controlSlug ||
+            c.id === controlSlug,
         )
 
         if (!foundControl) {
@@ -100,7 +100,10 @@ function SafeguardPageContent() {
         // Then get safeguards for this control
         const safeguardsResponse = await standardsService.getSafeguardsByControlId(foundControl.id, 1, 100)
         const foundSafeguard = safeguardsResponse.data.find(
-          (s) => generateSlug(s.nameEn) === safeguardSlug || generateSlug(s.nameAr) === safeguardSlug,
+          (s) =>
+            slugify(s.nameEn) === safeguardSlug ||
+            slugify(s.nameAr) === safeguardSlug ||
+            s.id === safeguardSlug,
         )
 
         if (!foundSafeguard) {

--- a/app/standards/[category]/[standard]/[control]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/page.tsx
@@ -9,7 +9,13 @@ import { ChevronLeft, Shield, ArrowRight } from "lucide-react"
 import Link from "next/link"
 import { useLanguage } from "@/components/language-provider"
 import { container } from "@/core/di/container"
-import type { Control, Standard, Safeguard, SafeguardsPaginatedResponse } from "@/core/domain/models/standard"
+import type {
+  Control,
+  Standard,
+  Safeguard,
+  SafeguardsPaginatedResponse,
+} from "@/core/domain/models/standard"
+import { slugify } from "@/lib/utils"
 
 export default function ControlPage() {
   return (
@@ -62,17 +68,13 @@ function ControlPageContent() {
         console.log("✅ Found standards:", allStandards.length)
 
         const foundStandard = allStandards.find((s) => {
-          const slugEn =
-            s.nameEn
-              ?.toLowerCase()
-              .replace(/\s+/g, "-")
-              .replace(/[^\w-]/g, "") || ""
-          const slugAr =
-            s.nameAr
-              ?.toLowerCase()
-              .replace(/\s+/g, "-")
-              .replace(/[^\w-]/g, "") || ""
-          return slugEn === standardSlug || slugAr === standardSlug
+          const slugEn = slugify(s.nameEn)
+          const slugAr = slugify(s.nameAr)
+          return (
+            slugEn === standardSlug ||
+            slugAr === standardSlug ||
+            s.id === standardSlug
+          )
         })
 
         if (!foundStandard) {
@@ -90,17 +92,13 @@ function ControlPageContent() {
         console.log("✅ Found controls:", controlsResponse.data.length)
 
         const foundControl = controlsResponse.data.find((c) => {
-          const slugEn =
-            c.nameEn
-              ?.toLowerCase()
-              .replace(/\s+/g, "-")
-              .replace(/[^\w-]/g, "") || ""
-          const slugAr =
-            c.nameAr
-              ?.toLowerCase()
-              .replace(/\s+/g, "-")
-              .replace(/[^\w-]/g, "") || ""
-          return slugEn === controlSlug || slugAr === controlSlug
+          const slugEn = slugify(c.nameEn)
+          const slugAr = slugify(c.nameAr)
+          return (
+            slugEn === controlSlug ||
+            slugAr === controlSlug ||
+            c.id === controlSlug
+          )
         })
 
         if (!foundControl) {
@@ -147,10 +145,7 @@ function ControlPageContent() {
   }, [standardSlug, controlSlug, standardsService])
 
   const handleSafeguardClick = (safeguard: Safeguard) => {
-    const safeguardSlug = (safeguard.nameEn || safeguard.nameAr || "")
-      .toLowerCase()
-      .replace(/\s+/g, "-")
-      .replace(/[^\w-]/g, "")
+    const safeguardSlug = slugify(safeguard.nameEn || safeguard.nameAr || "")
 
     console.log("🔗 Navigating to safeguard:", safeguardSlug)
     window.location.href = `/standards/${category}/${standardSlug}/${controlSlug}/${safeguardSlug}`

--- a/app/standards/[category]/[standard]/page.tsx
+++ b/app/standards/[category]/[standard]/page.tsx
@@ -12,6 +12,7 @@ import Link from "next/link"
 import { useLanguage } from "@/components/language-provider"
 import { container } from "@/core/di/container"
 import type { Standard, Control } from "@/core/domain/models/standard"
+import { slugify } from "@/lib/utils"
 
 export default function StandardPage() {
   return (
@@ -56,16 +57,14 @@ function StandardPageContent() {
 
         const allStandards = await standardsService.getAllStandards()
         const foundStandard = allStandards.find((s) => {
-          const slugEn = s.nameEn
-            .toLowerCase()
-            .replace(/\s+/g, "-")
-            .replace(/[^\w-]/g, "")
-          const slugAr = s.nameAr
-            .toLowerCase()
-            .replace(/\s+/g, "-")
-            .replace(/[^\w-]/g, "")
+          const slugEn = slugify(s.nameEn)
+          const slugAr = slugify(s.nameAr)
 
-          return slugEn === standardSlug || slugAr === standardSlug
+          return (
+            slugEn === standardSlug ||
+            slugAr === standardSlug ||
+            s.id === standardSlug
+          )
         })
 
         if (!foundStandard) {
@@ -222,10 +221,9 @@ function StandardPageContent() {
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {controls.map((control, index) => (
                   <Link
-                    href={`/standards/${category}/${standardSlug}/${control.nameEn
-                      .toLowerCase()
-                      .replace(/\s+/g, "-")
-                      .replace(/[^\w-]/g, "")}`}
+                    href={`/standards/${category}/${standardSlug}/${slugify(
+                      control.nameEn || control.nameAr || "",
+                    )}`}
                     key={control.id}
                   >
                     <Card className="h-full hover:shadow-lg transition-all duration-300 hover:scale-105 cursor-pointer group border-l-4 border-l-primary/20 hover:border-l-primary">


### PR DESCRIPTION
## Summary
- use slugify helper everywhere so slugs match link URLs
- update control, safeguard and technique pages to resolve items by slug or ID

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726b6b9fdc832e906ec7af46a6b501