### PR TITLE
Fallback slug to ID when English name missing

### DIFF
--- a/app/articles/ArticlesPageClient.tsx
+++ b/app/articles/ArticlesPageClient.tsx
@@ -144,7 +144,7 @@ function ArticleCard({ article, index }: ArticleCardProps) {
 
   // ALWAYS use English title for URL slug (regardless of current language)
   const englishTitle = article.titleEn || article.title || ""
-  const slug = slugify(englishTitle)
+  const slug = slugify(englishTitle, article.id)
 
   // Don't render if no title
   if (!displayTitle) {

--- a/app/awareness/[year]/AwarenessYearPageClient.tsx
+++ b/app/awareness/[year]/AwarenessYearPageClient.tsx
@@ -56,7 +56,7 @@ export default function AwarenessYearPageClient({ year }: AwarenessYearPageClien
 
   const getSlug = (item: any) => {
     const englishTitle = item.titleEn || item.title || ""
-    return slugify(englishTitle)
+    return slugify(englishTitle, item.id)
   }
 
   const handleDownload = (documentUrl: string, title: string) => {

--- a/app/awareness/[year]/[slug]/AwarenessDetailPageClient.tsx
+++ b/app/awareness/[year]/[slug]/AwarenessDetailPageClient.tsx
@@ -9,7 +9,6 @@ import { Separator } from "@/components/ui/separator"
 import { ArrowLeft, ArrowRight, Download, FileText, BookOpen, Shield, CheckCircle, AlertCircle } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { container } from "@/core/di/container"
-import { slugify } from "@/lib/utils"
 import MainLayout from "@/components/layouts/main-layout"
 
 interface AwarenessDetailPageClientProps {
@@ -41,23 +40,7 @@ export default function AwarenessDetailPageClient({ year, slug }: AwarenessDetai
       try {
         setLoading(true)
 
-        // First get the year ID
-        const years = await container.services.awareness.getAllAwarenessYears("", 1, 100)
-        const foundYear = years.data.find((y) => y.year.toString() === year)
-
-        if (!foundYear) {
-          setError("Year not found")
-          return
-        }
-
-        // Then get all awareness for that year
-        const awarenessData = await container.services.awareness.getAwarenessByYearId(foundYear.id, "", 1, 100)
-
-        // Find the specific awareness by slug
-        const foundAwareness = awarenessData.data.find((item) => {
-          const englishTitle = item.titleEn || item.title || ""
-          return slugify(englishTitle, item.id) === slug
-        })
+        const foundAwareness = await container.services.awareness.getAwarenessByYearAndSlug(year, slug)
 
         if (foundAwareness) {
           setAwareness(foundAwareness)

--- a/app/awareness/[year]/[slug]/AwarenessDetailPageClient.tsx
+++ b/app/awareness/[year]/[slug]/AwarenessDetailPageClient.tsx
@@ -56,7 +56,7 @@ export default function AwarenessDetailPageClient({ year, slug }: AwarenessDetai
         // Find the specific awareness by slug
         const foundAwareness = awarenessData.data.find((item) => {
           const englishTitle = item.titleEn || item.title || ""
-          return slugify(englishTitle) === slug
+          return slugify(englishTitle, item.id) === slug
         })
 
         if (foundAwareness) {

--- a/app/definitions/[slug]/DefinitionPageClient.tsx
+++ b/app/definitions/[slug]/DefinitionPageClient.tsx
@@ -24,7 +24,7 @@ export default function DefinitionPageClient({ definition, category }: Definitio
       ? definition.definitionText || definition.definitionEn
       : definition.definitionEn || definition.definitionText
   const categoryName = category ? (language === "ar" ? category.name : category.nameEn) : ""
-  const categorySlug = category ? slugify(category.nameEn || category.name) : ""
+  const categorySlug = category ? slugify(category.nameEn || category.name, category.id) : ""
 
   const getCategorySlug = () => {
     if (!category) return "#"

--- a/app/definitions/category/[slug]/DefinitionCategoryPageClient.tsx
+++ b/app/definitions/category/[slug]/DefinitionCategoryPageClient.tsx
@@ -59,7 +59,7 @@ export default function DefinitionCategoryPageClient({
           {definitions.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {definitions.map((definition) => {
-                const definitionSlug = slugify(definition.termEn || definition.term)
+                const definitionSlug = slugify(definition.termEn || definition.term, definition.id)
                 const displayTerm =
                   language === "ar" ? definition.term || definition.termEn : definition.termEn || definition.term
                 const displayDefinition =

--- a/app/instructions/category/[slug]/[year]/InstructionYearPageClient.tsx
+++ b/app/instructions/category/[slug]/[year]/InstructionYearPageClient.tsx
@@ -35,7 +35,7 @@ function InstructionCard({
 }) {
   const title = language === "ar" ? instruction.title : instruction.titleEn
   const summary = language === "ar" ? instruction.summary : instruction.summaryEn
-  const slug = slugify(instruction.titleEn || instruction.title)
+  const slug = slugify(instruction.titleEn || instruction.title, instruction.id)
 
   return (
     <Card className="group hover:shadow-lg transition-all duration-300 border-l-4 border-l-primary/20 hover:border-l-primary">

--- a/app/instructions/category/[slug]/[year]/[instruction]/page.tsx
+++ b/app/instructions/category/[slug]/[year]/[instruction]/page.tsx
@@ -19,7 +19,9 @@ async function findInstructionBySlugAndYear(instructionSlug: string, categorySlu
 
     // First, get the category and year to get the year ID
     const categoriesResponse = await container.services.instructionCategories.getAllCategories()
-    const category = categoriesResponse.data.find((cat) => slugify(cat.nameEn || cat.name) === categorySlug)
+    const category = categoriesResponse.data.find(
+      (cat) => slugify(cat.nameEn || cat.name, cat.id) === categorySlug,
+    )
 
     if (!category) {
       console.log(`❌ Category not found for slug: ${categorySlug}`)
@@ -45,7 +47,7 @@ async function findInstructionBySlugAndYear(instructionSlug: string, categorySlu
 
     // Find the instruction by slug
     const instruction = instructionsResponse.data.find((inst) => {
-      const instSlug = slugify(inst.titleEn || inst.title)
+      const instSlug = slugify(inst.titleEn || inst.title, inst.id)
       console.log(`🔍 Comparing instruction slug: ${instSlug} with target: ${instructionSlug}`)
       return instSlug === instructionSlug
     })

--- a/app/laws/[slug]/LawPageClient.tsx
+++ b/app/laws/[slug]/LawPageClient.tsx
@@ -37,7 +37,7 @@ export default function LawPageClient({ law, category }: LawPageClientProps) {
   const getCategorySlug = () => {
     if (!category) return ""
     const categoryName = category.nameEn || category.name || ""
-    return slugify(categoryName)
+    return slugify(categoryName, category.id)
   }
 
   const lawTitle = getTitle(law)

--- a/app/laws/category/[slug]/LawCategoryPageClient.tsx
+++ b/app/laws/category/[slug]/LawCategoryPageClient.tsx
@@ -80,7 +80,7 @@ function LawCard({ item }: { item: Law }) {
 
   // ALWAYS use English title for URL slug (regardless of current language)
   const englishTitle = item?.titleEn || item?.title || ""
-  const slug = slugify(englishTitle)
+  const slug = slugify(englishTitle, item.id)
 
   const displayTitle = getDisplayTitle(item)
   const displaySummary = getDisplaySummary(item)

--- a/app/lectures/LecturesPageClient.tsx
+++ b/app/lectures/LecturesPageClient.tsx
@@ -43,7 +43,7 @@ export default function LecturesPageClient({ initialLectures, initialSearch, ini
 
   const getLectureSlug = (lecture: ApiLecture) => {
     const englishName = lecture.nameEn || lecture.nameAr || ""
-    return slugify(englishName)
+    return slugify(englishName, lecture.id)
   }
 
   const getDocumentUrl = (lecture: ApiLecture) => {

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -33,8 +33,8 @@ export default function NewsDetailPage() {
 
         // Find news by matching slug (ALWAYS use English title for slug matching)
         const foundNews = allNews.find((item: News) => {
-          const englishTitle = item.titleEn || item.title || ""
-          const itemSlug = slugify(englishTitle)
+          const englishTitle = item.titleEn || ""
+          const itemSlug = slugify(englishTitle, item.id)
           const matches = itemSlug === slug
           if (matches) {
             console.log(`✅ Found matching news: ${englishTitle} (slug: ${itemSlug}, id: ${item.id})`)

--- a/app/news/category/[category]/page.tsx
+++ b/app/news/category/[category]/page.tsx
@@ -63,8 +63,8 @@ function NewsCategoryContent() {
 
         const matchedApiCategory = apiCategories.find((cat: any) => {
           // ALWAYS try to match against English name first
-          const nameEnSlug = slugify(cat.nameEn || cat.name || "")
-          const nameSlug = slugify(cat.name || cat.nameEn || "")
+          const nameEnSlug = slugify(cat.nameEn || "", cat.id)
+          const nameSlug = slugify(cat.name || "", cat.id)
 
           // Prioritize English name matching
           const matches = categoryUrl === nameEnSlug || categoryUrl === nameSlug
@@ -217,8 +217,8 @@ function NewsCard({ item }: { item: News }) {
   }
 
   // ALWAYS use English title for URL slug (regardless of current language)
-  const englishTitle = item?.titleEn || item?.title || ""
-  const slug = slugify(englishTitle)
+  const englishTitle = item?.titleEn || ""
+  const slug = slugify(englishTitle, item.id)
 
   const displayTitle = getDisplayTitle(item)
   const displaySummary = getDisplaySummary(item)

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -119,8 +119,8 @@ function NewsCard({ item }: { item: News }) {
   }
 
   // ALWAYS use English title for URL slug (regardless of current language)
-  const englishTitle = item?.titleEn || item?.title || ""
-  const slug = slugify(englishTitle)
+  const englishTitle = item?.titleEn || ""
+  const slug = slugify(englishTitle, item.id)
 
   const displayTitle = getDisplayTitle(item)
   const displaySummary = getDisplaySummary(item)

--- a/app/presentations/PresentationsPageClient.tsx
+++ b/app/presentations/PresentationsPageClient.tsx
@@ -56,7 +56,7 @@ export default function PresentationsPageClient({
 
   const getPresentationSlug = (presentation: ApiPresentation) => {
     const englishName = presentation.nameEn || presentation.nameAr || ""
-    return slugify(englishName)
+    return slugify(englishName, presentation.id)
   }
 
   const getPresentationUrl = (presentation: ApiPresentation) => {

--- a/app/regulation/[slug]/RegulationPageClient.tsx
+++ b/app/regulation/[slug]/RegulationPageClient.tsx
@@ -72,7 +72,9 @@ export default function RegulationPageClient({ regulationSlug }: RegulationPageC
 
   // Get category slug for the back link
   const getCategorySlug = () => {
-    return regulation?.categoryNameEn ? slugify(regulation.categoryNameEn) : "all"
+    return regulation?.categoryNameEn
+      ? slugify(regulation.categoryNameEn, regulation.regulationCategoryId)
+      : "all"
   }
 
   const formatDate = (dateString: string) => {

--- a/app/regulation/category/[slug]/RegulationCategoryPageClient.tsx
+++ b/app/regulation/category/[slug]/RegulationCategoryPageClient.tsx
@@ -154,7 +154,7 @@ function RegulationCard({ regulation }: { regulation: any }) {
   const summary = language === "ar" ? regulation.summary : regulation.summaryEn
 
   // Create slug from English title for URL
-  const slug = slugify(regulation.titleEn)
+  const slug = slugify(regulation.titleEn, regulation.id)
 
   return (
     <Link href={`/regulation/${slug}`}>

--- a/app/regulation/category/all/AllRegulationsPageClient.tsx
+++ b/app/regulation/category/all/AllRegulationsPageClient.tsx
@@ -134,7 +134,7 @@ function RegulationCard({ regulation }: { regulation: any }) {
   const summary = language === "ar" ? regulation.summary : regulation.summaryEn
 
   // Create slug from English title for URL
-  const slug = slugify(regulation.titleEn)
+  const slug = slugify(regulation.titleEn, regulation.id)
 
   return (
     <Link href={`/regulation/${slug}`}>

--- a/app/security-procedures/SecurityProceduresPageClient.tsx
+++ b/app/security-procedures/SecurityProceduresPageClient.tsx
@@ -172,7 +172,7 @@ function StandardCard({ standard, index }: { standard: any; index: number }) {
   const description =
     language === "ar" ? standard.standardDescription : standard.descriptionEn;
 
-  const slug = createSecurityProcedureSlug(standard.nameEn);
+  const slug = createSecurityProcedureSlug(standard.nameEn, standard.id);
   const formattedDate = standard.approvalDate
     ? new Date(standard.approvalDate).toLocaleDateString()
     : null;

--- a/app/standards/StandardsPageClient.tsx
+++ b/app/standards/StandardsPageClient.tsx
@@ -79,7 +79,7 @@ export default function StandardsPageClient({
             {categories.length > 0 ? (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                 {categories.map((category, index) => {
-                  const categorySlug = slugify(category.nameEn);
+                  const categorySlug = slugify(category.nameEn, category.id);
 
                   return (
                     <motion.div

--- a/app/standards/[category]/StandardCategoryPageClient.tsx
+++ b/app/standards/[category]/StandardCategoryPageClient.tsx
@@ -43,8 +43,8 @@ export default function StandardCategoryPageClient({
 
   const handleStandardClick = (standard: Standard) => {
     console.log("Standard clicked:", standard)
-    const categorySlug = slugify(category.nameEn)
-    const standardSlug = slugify(standard.nameEn)
+    const categorySlug = slugify(category.nameEn, category.id)
+    const standardSlug = slugify(standard.nameEn, standard.id)
     const url = `/standards/${categorySlug}/${standardSlug}`
     console.log("Navigating to:", url)
     router.push(url)

--- a/app/standards/[category]/[standard]/[control]/[safeguard]/[technique]/[implementation]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/[safeguard]/[technique]/[implementation]/page.tsx
@@ -67,8 +67,8 @@ function ImplementationStepPageContent() {
         const allStandards = await standardsService.getAllStandards()
         const foundStandard = allStandards.find(
           (s) =>
-            slugify(s.nameEn) === standardSlug ||
-            slugify(s.nameAr) === standardSlug ||
+            slugify(s.nameEn || "", s.id) === standardSlug ||
+            slugify(s.nameAr || "", s.id) === standardSlug ||
             s.id === standardSlug,
         )
 
@@ -84,8 +84,8 @@ function ImplementationStepPageContent() {
         const controlsResponse = await standardsService.getControlsByStandardId(foundStandard.id, 1, 100)
         const foundControl = controlsResponse.data.find(
           (c) =>
-            slugify(c.nameEn) === controlSlug ||
-            slugify(c.nameAr) === controlSlug ||
+            slugify(c.nameEn || "", c.id) === controlSlug ||
+            slugify(c.nameAr || "", c.id) === controlSlug ||
             c.id === controlSlug,
         )
 
@@ -101,8 +101,8 @@ function ImplementationStepPageContent() {
         const safeguardsResponse = await standardsService.getSafeguardsByControlId(foundControl.id, 1, 100)
         const foundSafeguard = safeguardsResponse.data.find(
           (s) =>
-            slugify(s.nameEn) === safeguardSlug ||
-            slugify(s.nameAr) === safeguardSlug ||
+            slugify(s.nameEn || "", s.id) === safeguardSlug ||
+            slugify(s.nameAr || "", s.id) === safeguardSlug ||
             s.id === safeguardSlug,
         )
 
@@ -118,8 +118,8 @@ function ImplementationStepPageContent() {
         const techniquesResponse = await standardsService.getTechniquesBySafeguardId(foundSafeguard.id, 1, 100)
         const foundTechnique = techniquesResponse.data.find(
           (t) =>
-            slugify(t.nameEn) === techniqueSlug ||
-            slugify(t.nameAr) === techniqueSlug ||
+            slugify(t.nameEn || "", t.id) === techniqueSlug ||
+            slugify(t.nameAr || "", t.id) === techniqueSlug ||
             t.id === techniqueSlug,
         )
 
@@ -135,8 +135,8 @@ function ImplementationStepPageContent() {
         const stepsResponse = await standardsService.getImplementationStepsByTechniqueId(foundTechnique.id, 1, 100)
         const foundImplementationStep = stepsResponse.data.find(
           (step) =>
-            slugify(step.nameEn) === implementationSlug ||
-            slugify(step.nameAr) === implementationSlug ||
+            slugify(step.nameEn || "", step.id) === implementationSlug ||
+            slugify(step.nameAr || "", step.id) === implementationSlug ||
             step.id === implementationSlug,
         )
 

--- a/app/standards/[category]/[standard]/[control]/[safeguard]/[technique]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/[safeguard]/[technique]/page.tsx
@@ -61,8 +61,8 @@ function TechniquePageContent() {
         const allStandards = await standardsService.getAllStandards()
         const foundStandard = allStandards.find(
           (s) =>
-            slugify(s.nameEn) === standardSlug ||
-            slugify(s.nameAr) === standardSlug ||
+            slugify(s.nameEn || "", s.id) === standardSlug ||
+            slugify(s.nameAr || "", s.id) === standardSlug ||
             s.id === standardSlug,
         )
 
@@ -78,8 +78,8 @@ function TechniquePageContent() {
         const controlsResponse = await standardsService.getControlsByStandardId(foundStandard.id, 1, 100)
         const foundControl = controlsResponse.data.find(
           (c) =>
-            slugify(c.nameEn) === controlSlug ||
-            slugify(c.nameAr) === controlSlug ||
+            slugify(c.nameEn || "", c.id) === controlSlug ||
+            slugify(c.nameAr || "", c.id) === controlSlug ||
             c.id === controlSlug,
         )
 
@@ -95,8 +95,8 @@ function TechniquePageContent() {
         const safeguardsResponse = await standardsService.getSafeguardsByControlId(foundControl.id, 1, 100)
         const foundSafeguard = safeguardsResponse.data.find(
           (s) =>
-            slugify(s.nameEn) === safeguardSlug ||
-            slugify(s.nameAr) === safeguardSlug ||
+            slugify(s.nameEn || "", s.id) === safeguardSlug ||
+            slugify(s.nameAr || "", s.id) === safeguardSlug ||
             s.id === safeguardSlug,
         )
 
@@ -112,8 +112,8 @@ function TechniquePageContent() {
         const techniquesResponse = await standardsService.getTechniquesBySafeguardId(foundSafeguard.id, 1, 100)
         const foundTechnique = techniquesResponse.data.find(
           (t) =>
-            slugify(t.nameEn) === techniqueSlug ||
-            slugify(t.nameAr) === techniqueSlug ||
+            slugify(t.nameEn || "", t.id) === techniqueSlug ||
+            slugify(t.nameAr || "", t.id) === techniqueSlug ||
             t.id === techniqueSlug,
         )
 
@@ -286,7 +286,7 @@ function TechniquePageContent() {
             ) : implementationSteps.length > 0 ? (
               <div className="grid gap-4">
                 {implementationSteps.map((step) => {
-                  const stepSlug = slugify(step.nameEn || step.nameAr)
+                  const stepSlug = slugify(step.nameEn || step.nameAr, step.id)
                   return (
                     <Link
                       key={step.id}

--- a/app/standards/[category]/[standard]/[control]/[safeguard]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/[safeguard]/page.tsx
@@ -49,7 +49,7 @@ function SafeguardPageContent() {
   const standardsService = container.standardsService
 
   const handleTechniqueClick = (technique: Technique) => {
-    const techniqueSlug = slugify(technique.nameEn || technique.nameAr)
+    const techniqueSlug = slugify(technique.nameEn || technique.nameAr, technique.id)
     const url = `/standards/${category}/${standardSlug}/${controlSlug}/${safeguardSlug}/${techniqueSlug}`
     console.log("🔗 Navigating to technique:", url)
     window.location.href = url
@@ -67,8 +67,8 @@ function SafeguardPageContent() {
         const allStandards = await standardsService.getAllStandards()
         const foundStandard = allStandards.find(
           (s) =>
-            slugify(s.nameEn) === standardSlug ||
-            slugify(s.nameAr) === standardSlug ||
+            slugify(s.nameEn || "", s.id) === standardSlug ||
+            slugify(s.nameAr || "", s.id) === standardSlug ||
             s.id === standardSlug,
         )
 
@@ -84,8 +84,8 @@ function SafeguardPageContent() {
         const controlsResponse = await standardsService.getControlsByStandardId(foundStandard.id, 1, 100)
         const foundControl = controlsResponse.data.find(
           (c) =>
-            slugify(c.nameEn) === controlSlug ||
-            slugify(c.nameAr) === controlSlug ||
+            slugify(c.nameEn || "", c.id) === controlSlug ||
+            slugify(c.nameAr || "", c.id) === controlSlug ||
             c.id === controlSlug,
         )
 
@@ -101,8 +101,8 @@ function SafeguardPageContent() {
         const safeguardsResponse = await standardsService.getSafeguardsByControlId(foundControl.id, 1, 100)
         const foundSafeguard = safeguardsResponse.data.find(
           (s) =>
-            slugify(s.nameEn) === safeguardSlug ||
-            slugify(s.nameAr) === safeguardSlug ||
+            slugify(s.nameEn || "", s.id) === safeguardSlug ||
+            slugify(s.nameAr || "", s.id) === safeguardSlug ||
             s.id === safeguardSlug,
         )
 

--- a/app/standards/[category]/[standard]/[control]/page.tsx
+++ b/app/standards/[category]/[standard]/[control]/page.tsx
@@ -68,8 +68,8 @@ function ControlPageContent() {
         console.log("✅ Found standards:", allStandards.length)
 
         const foundStandard = allStandards.find((s) => {
-          const slugEn = slugify(s.nameEn)
-          const slugAr = slugify(s.nameAr)
+          const slugEn = slugify(s.nameEn || "", s.id)
+          const slugAr = slugify(s.nameAr || "", s.id)
           return (
             slugEn === standardSlug ||
             slugAr === standardSlug ||
@@ -92,8 +92,8 @@ function ControlPageContent() {
         console.log("✅ Found controls:", controlsResponse.data.length)
 
         const foundControl = controlsResponse.data.find((c) => {
-          const slugEn = slugify(c.nameEn)
-          const slugAr = slugify(c.nameAr)
+          const slugEn = slugify(c.nameEn || "", c.id)
+          const slugAr = slugify(c.nameAr || "", c.id)
           return (
             slugEn === controlSlug ||
             slugAr === controlSlug ||
@@ -145,7 +145,7 @@ function ControlPageContent() {
   }, [standardSlug, controlSlug, standardsService])
 
   const handleSafeguardClick = (safeguard: Safeguard) => {
-    const safeguardSlug = slugify(safeguard.nameEn || safeguard.nameAr || "")
+    const safeguardSlug = slugify(safeguard.nameEn || safeguard.nameAr || "", safeguard.id)
 
     console.log("🔗 Navigating to safeguard:", safeguardSlug)
     window.location.href = `/standards/${category}/${standardSlug}/${controlSlug}/${safeguardSlug}`

--- a/app/standards/[category]/[standard]/page.tsx
+++ b/app/standards/[category]/[standard]/page.tsx
@@ -57,8 +57,8 @@ function StandardPageContent() {
 
         const allStandards = await standardsService.getAllStandards()
         const foundStandard = allStandards.find((s) => {
-          const slugEn = slugify(s.nameEn)
-          const slugAr = slugify(s.nameAr)
+          const slugEn = slugify(s.nameEn || "", s.id)
+          const slugAr = slugify(s.nameAr || "", s.id)
 
           return (
             slugEn === standardSlug ||
@@ -223,6 +223,7 @@ function StandardPageContent() {
                   <Link
                     href={`/standards/${category}/${standardSlug}/${slugify(
                       control.nameEn || control.nameAr || "",
+                      control.id,
                     )}`}
                     key={control.id}
                   >

--- a/app/standards/[category]/page.tsx
+++ b/app/standards/[category]/page.tsx
@@ -18,7 +18,9 @@ async function findCategoryBySlug(slug: string) {
     console.log(`🔍 Finding standard category by slug: ${slug}`)
 
     const categoriesResponse = await container.services.standards.getAllStandardCategories(1, 100)
-    const category = categoriesResponse.data.find((cat) => slugify(cat.nameEn) === slug)
+    const category = categoriesResponse.data.find(
+      (cat) => slugify(cat.nameEn || "", cat.id) === slug,
+    )
 
     if (!category) {
       console.log(`❌ Category not found for slug: ${slug}`)

--- a/components/instruction-card.tsx
+++ b/components/instruction-card.tsx
@@ -20,7 +20,7 @@ export function InstructionCard({ instruction, categorySlug, yearNumber }: Instr
 
   const title = language === "ar" ? instruction.title : instruction.titleEn
   const summary = language === "ar" ? instruction.summary : instruction.summaryEn
-  const slug = slugify(instruction.titleEn || instruction.title)
+  const slug = slugify(instruction.titleEn || instruction.title, instruction.id)
 
   return (
     <Card className="h-full hover:shadow-lg transition-shadow duration-200">

--- a/components/news-card.tsx
+++ b/components/news-card.tsx
@@ -59,8 +59,8 @@ export default function NewsCard({
   const fullContent = language === "ar" ? fullDescription || summary || "" : fullDescription || summaryEn || ""
 
   // ALWAYS use English title for URL slug (regardless of current language)
-  const englishTitle = titleEn || title || ""
-  const newsSlug = slugify(englishTitle)
+  const englishTitle = titleEn || ""
+  const newsSlug = slugify(englishTitle, id)
 
   // Don't render if no title
   if (!displayTitle) {

--- a/components/news-carousel.tsx
+++ b/components/news-carousel.tsx
@@ -132,8 +132,8 @@ export default function NewsCarousel() {
       : currentNews.titleEn || currentNews.title || "News"
 
   // ALWAYS use English title for URL slug (regardless of current language)
-  const englishTitle = currentNews.titleEn || currentNews.title || "news"
-  const newsSlug = slugify(englishTitle)
+  const englishTitle = currentNews.titleEn || ""
+  const newsSlug = slugify(englishTitle, currentNews.id)
 
   // ONLY GET SUMMARY - NO FALLBACK TO CONTENT!
   const newsSummary =

--- a/components/sections/awareness-section.tsx
+++ b/components/sections/awareness-section.tsx
@@ -229,7 +229,7 @@ function CategoryNewsContent({
       return categoryUrlMap[catId]
     }
     // Always use English name for URL slug
-    return slugify(catNameEn)
+    return slugify(catNameEn, catId)
   }
 
   const categoryUrl = getCategoryUrl(categoryId, categoryNameEn)
@@ -282,7 +282,7 @@ function NewsCard({ item, index }: NewsCardProps) {
 
   // ALWAYS use English title for URL slug (regardless of current language)
   const englishTitle = item.titleEn || item.title || ""
-  const slug = slugify(englishTitle)
+  const slug = slugify(englishTitle, item.id)
 
   console.log(`News card linking to /news/${slug} (ID: ${item.id})`)
 
@@ -363,7 +363,7 @@ function ArticleCard({ item, index }: ArticleCardProps) {
 
   // ALWAYS use English title for URL slug (regardless of current language)
   const englishTitle = item.titleEn || item.title || ""
-  const slug = slugify(englishTitle)
+  const slug = slugify(englishTitle, item.id)
 
   // Don't render if no title
   if (!displayTitle) {
@@ -440,7 +440,7 @@ function CurrentYearAwarenessContent() {
 
   const getSlug = (item: any) => {
     const englishTitle = item.titleEn || item.title || ""
-    return slugify(englishTitle)
+    return slugify(englishTitle, item.id)
   }
 
   if (loading) {

--- a/components/sections/cybersecurity-regulation-section.tsx
+++ b/components/sections/cybersecurity-regulation-section.tsx
@@ -59,7 +59,7 @@ export default function CybersecurityRegulationSection() {
   const getActiveCategorySlug = () => {
     if (!activeCategory) return "all"
     const activeItem = categories.find((c) => c.id === activeCategory)
-    return activeItem ? slugify(activeItem.name_En) : "all"
+    return activeItem ? slugify(activeItem.name_En, activeItem.id) : "all"
   }
 
   if (loading && !activeCategory) {
@@ -186,7 +186,7 @@ function RegulationCard({ item, index }: RegulationCardProps) {
   const summary = language === "ar" ? item.summary : item.summaryEn
 
   // Create slug from English title for URL
-  const slug = slugify(item.titleEn)
+  const slug = slugify(item.titleEn, item.id)
 
   return (
     <motion.div

--- a/components/sections/media-library-section.tsx
+++ b/components/sections/media-library-section.tsx
@@ -315,7 +315,7 @@ const LectureCard = ({ lecture }: { lecture: ApiLecture }) => {
 
   const handleCardClick = () => {
     const englishTitle = lecture.nameEn || ""
-    const slug = slugify(englishTitle)
+    const slug = slugify(englishTitle, lecture.id)
     router.push(`/lectures/${slug}`)
   }
 
@@ -361,7 +361,7 @@ const PresentationCard = ({ presentation }: { presentation: ApiPresentation }) =
 
   const handleCardClick = () => {
     const englishTitle = presentation.nameEn || ""
-    const slug = slugify(englishTitle)
+    const slug = slugify(englishTitle, presentation.id)
     router.push(`/presentations/${slug}`)
   }
 

--- a/components/sections/security-instructions-content.tsx
+++ b/components/sections/security-instructions-content.tsx
@@ -72,7 +72,7 @@ export default function SecurityInstructionsContent() {
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {categories.map((category, index) => {
         // Create slug from category name
-        const categorySlug = slugify(language === "ar" ? category.nameEn : category.nameEn)
+        const categorySlug = slugify(category.nameEn, category.id)
 
         // Choose icon based on category name
         const isGroup = category.nameEn.toLowerCase().includes("group") || category.name.includes("مجموعة")

--- a/components/sections/standards-section.tsx
+++ b/components/sections/standards-section.tsx
@@ -228,7 +228,7 @@ export default function CybersecurityConceptsSection() {
                       {(isRtl ? [...(definitions[category.id] || [])].reverse() : definitions[category.id] || [])
                         .slice(0, 6)
                         .map((item, index) => {
-                          const definitionSlug = slugify(item.termEn || item.term)
+                          const definitionSlug = slugify(item.termEn || item.term, item.id)
                           return (
                             <Link href={`/definitions/${definitionSlug}`} key={item.id}>
                               <motion.div
@@ -258,7 +258,7 @@ export default function CybersecurityConceptsSection() {
                     </div>
                     <div className="mt-8 text-center">
                       <Link
-                        href={`/definitions/category/${slugify(category.nameEn || category.name)}`}
+                        href={`/definitions/category/${slugify(category.nameEn || category.name, category.id)}`}
                         className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90"
                       >
                         {t("common.viewAll")} {language === "ar" ? category.name : category.nameEn}
@@ -304,7 +304,7 @@ export default function CybersecurityConceptsSection() {
                       {(isRtl ? [...(laws[category.id] || [])].reverse() : laws[category.id] || [])
                         .slice(0, 6)
                         .map((item, index) => {
-                          const lawSlug = slugify(item.titleEn || item.title)
+                          const lawSlug = slugify(item.titleEn || item.title, item.id)
                           return (
                             <Link href={`/laws/${lawSlug}`} key={item.id}>
                               <motion.div
@@ -339,7 +339,7 @@ export default function CybersecurityConceptsSection() {
                     </div>
                     <div className="mt-8 text-center">
                       <Link
-                        href={`/laws/category/${slugify(category.nameEn || category.name)}`}
+                        href={`/laws/category/${slugify(category.nameEn || category.name, category.id)}`}
                         className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90"
                       >
                         {t("common.viewAll")} {language === "ar" ? category.name : category.nameEn}
@@ -406,7 +406,7 @@ export default function CybersecurityConceptsSection() {
                 const categoryStandards = standardsByCategory[category.id] || []
                 const displayStandards = categoryStandards.slice(0, 2)
                 const remainingCount = Math.max(0, categoryStandards.length - 2)
-                const categorySlug = slugify(category.nameEn)
+                const categorySlug = slugify(category.nameEn, category.id)
 
                 // Get appropriate icon
                 const iconKey = category.nameEn.toLowerCase() as keyof typeof icons

--- a/core/data/repositories/articles-repository-impl.ts
+++ b/core/data/repositories/articles-repository-impl.ts
@@ -44,11 +44,8 @@ export class ArticlesRepositoryImpl implements ArticlesRepository {
 
       // Find the article item with a matching slug
       const foundArticle = allArticles.find((article) => {
-        const titleSlug = slugify(article.title || "")
-        const titleEnSlug = slugify(article.titleEn || "")
-
-        // Check if either slug matches
-        const matches = slug === titleSlug || slug === titleEnSlug
+        const slugToMatch = slugify(article.titleEn || "", article.id)
+        const matches = slug === slugToMatch
         if (matches) {
           console.log(`Found matching article with ID: ${article.id}`)
         }

--- a/core/data/repositories/awareness-repository-impl.ts
+++ b/core/data/repositories/awareness-repository-impl.ts
@@ -1,6 +1,7 @@
 import type { ApiDataSource } from "../sources/api-data-source"
 import type { AwarenessRepository } from "../../domain/repositories/awareness-repository"
 import type { AwarenessResponse, AwarenessYearResponse, Awareness, AwarenessYear } from "../../domain/models/awareness"
+import { slugify } from "@/lib/utils"
 
 export class AwarenessRepositoryImpl implements AwarenessRepository {
   constructor(private apiDataSource: ApiDataSource) {}
@@ -50,5 +51,26 @@ export class AwarenessRepositoryImpl implements AwarenessRepository {
 
   async getAwarenessById(id: string): Promise<Awareness> {
     return this.apiDataSource.get(`/Awareness/${id}`)
+  }
+
+  async getAwarenessByYearAndSlug(year: string, slug: string): Promise<Awareness | null> {
+    try {
+      // Find year ID first
+      const years = await this.getAllAwarenessYears("", 1, 100)
+      const foundYear = years.data.find((y) => y.year.toString() === year)
+      if (!foundYear) return null
+
+      // Fetch awareness items for that year and find by slug
+      const awarenessData = await this.getAwarenessByYearId(foundYear.id, "", 1, 100)
+      const item = awarenessData.data.find((aw) => {
+        const titleEn = aw.titleEn || aw.title || ""
+        return slugify(titleEn, aw.id) === slug
+      })
+
+      return item || null
+    } catch (error) {
+      console.error(`Error finding awareness by slug ${slug} for year ${year}:`, error)
+      return null
+    }
   }
 }

--- a/core/data/repositories/definitions-repository-impl.ts
+++ b/core/data/repositories/definitions-repository-impl.ts
@@ -114,7 +114,7 @@ export class DefinitionsRepositoryImpl implements DefinitionsRepository {
 
         const foundDefinition = definitionsResponse.data.find((definition) => {
           const englishTerm = definition.termEn || definition.term || ""
-          const definitionSlug = slugify(englishTerm)
+          const definitionSlug = slugify(englishTerm, definition.id)
           return definitionSlug === slug
         })
 
@@ -135,7 +135,7 @@ export class DefinitionsRepositoryImpl implements DefinitionsRepository {
       const response = await this.getAllCategories(1, 100)
       const foundCategory = response.data.find((category) => {
         const englishName = category.nameEn || category.name || ""
-        const categorySlug = slugify(englishName)
+        const categorySlug = slugify(englishName, category.id)
         return categorySlug === slug
       })
 

--- a/core/data/repositories/instruction-categories-repository-impl.ts
+++ b/core/data/repositories/instruction-categories-repository-impl.ts
@@ -57,12 +57,10 @@ export class InstructionCategoriesRepositoryImpl implements InstructionCategorie
       const allCategories = await this.getAllCategories(1, 100)
 
       // Find the category with matching slug
-      const category = allCategories.data.find(
-        (cat) =>
-          slugify(cat.nameEn) === slug ||
-          slugify(cat.nameEn).toLowerCase() === slug.toLowerCase() ||
-          slugify(cat.nameEn) === slug,
-      )
+      const category = allCategories.data.find((cat) => {
+        const slugEn = slugify(cat.nameEn || "", cat.id)
+        return slugEn === slug || slugEn.toLowerCase() === slug.toLowerCase()
+      })
 
       if (category) {
         console.log(`✅ Found category for slug ${slug}:`, category)

--- a/core/data/repositories/laws-repository-impl.ts
+++ b/core/data/repositories/laws-repository-impl.ts
@@ -54,7 +54,7 @@ export class LawsRepositoryImpl implements LawsRepository {
       const response = await this.getAllCategories(1, 100) // Get all categories
       const category = response.data.find((cat) => {
         const englishName = cat.nameEn || cat.name || ""
-        const categorySlug = slugify(englishName)
+        const categorySlug = slugify(englishName, cat.id)
         return categorySlug === slug
       })
       return category || null
@@ -73,7 +73,7 @@ export class LawsRepositoryImpl implements LawsRepository {
         const laws = await this.getLawsByCategory(category.id, 1, 100)
         const law = laws.data.find((law) => {
           const englishTitle = law.titleEn || law.title || ""
-          const lawSlug = slugify(englishTitle)
+          const lawSlug = slugify(englishTitle, law.id)
           return lawSlug === slug
         })
         if (law) return law

--- a/core/data/repositories/media-repository-impl.ts
+++ b/core/data/repositories/media-repository-impl.ts
@@ -166,7 +166,7 @@ export class MediaRepositoryImpl implements MediaRepository {
       // Find lecture by slug
       const foundLecture = transformedData.find((lecture) => {
         const englishTitle = lecture.nameEn || ""
-        const lectureSlug = slugify(englishTitle)
+        const lectureSlug = slugify(englishTitle, lecture.id)
         return lectureSlug === slug
       })
 
@@ -251,7 +251,7 @@ export class MediaRepositoryImpl implements MediaRepository {
       // Find presentation by slug
       const foundPresentation = transformedData.find((presentation) => {
         const englishTitle = presentation.nameEn || ""
-        const presentationSlug = slugify(englishTitle)
+        const presentationSlug = slugify(englishTitle, presentation.id)
         return presentationSlug === slug
       })
 

--- a/core/data/repositories/news-repository-impl.ts
+++ b/core/data/repositories/news-repository-impl.ts
@@ -59,11 +59,8 @@ export class NewsRepositoryImpl implements NewsRepository {
 
       // Find the news item with a matching slug
       const foundNews = allNews.find((news) => {
-        const titleSlug = slugify(news.title || "")
-        const titleEnSlug = slugify(news.titleEn || "")
-
-        // Check if either slug matches
-        const matches = slug === titleSlug || slug === titleEnSlug
+        const slugToMatch = slugify(news.titleEn || "", news.id)
+        const matches = slug === slugToMatch
         if (matches) {
           console.log(`Found matching news with ID: ${news.id}`)
         }

--- a/core/data/repositories/regulation-categories-repository-impl.ts
+++ b/core/data/repositories/regulation-categories-repository-impl.ts
@@ -73,14 +73,12 @@ export class RegulationCategoriesRepositoryImpl implements RegulationCategoriesR
       // Get all categories first (with a large pageSize to ensure we get all)
       const allCategories = await this.getAllCategories(1, 100)
 
-      // Find the category with matching slug (based on English name)
-      // Make sure to normalize the slugs for comparison
-      const category = allCategories.data.find(
-        (cat) =>
-          slugify(cat.name_En) === slug ||
-          slugify(cat.name_En).toLowerCase() === slug.toLowerCase() ||
-          slugify(cat.name) === slug,
-      )
+      // Find the category with matching slug (based on English or Arabic name or ID)
+      const category = allCategories.data.find((cat) => {
+        const slugEn = slugify(cat.name_En || "", cat.id)
+        const slugAr = slugify(cat.name || "", cat.id)
+        return slugEn === slug || slugEn.toLowerCase() === slug.toLowerCase() || slugAr === slug
+      })
 
       console.log(`🔍 Category search result:`, category ? `Found: ${category.name_En}` : "Not found")
 

--- a/core/data/repositories/regulations-repository-impl.ts
+++ b/core/data/repositories/regulations-repository-impl.ts
@@ -116,8 +116,12 @@ export class RegulationsRepositoryImpl implements RegulationsRepository {
       // Get all regulations first (with a larger page size to increase chances of finding the right one)
       const allRegulations = await this.getAllRegulations(1, 100)
 
-      // Find the regulation with matching slug (based on English title)
-      const regulation = allRegulations.data.find((reg) => slugify(reg.titleEn) === slug || slugify(reg.title) === slug)
+      // Find the regulation with matching slug (based on English or Arabic title or ID)
+      const regulation = allRegulations.data.find((reg) => {
+        const slugEn = slugify(reg.titleEn || "", reg.id)
+        const slugAr = slugify(reg.title || "", reg.id)
+        return slugEn === slug || slugAr === slug
+      })
 
       return regulation || null
     } catch (error) {

--- a/core/domain/repositories/awareness-repository.ts
+++ b/core/domain/repositories/awareness-repository.ts
@@ -6,4 +6,5 @@ export interface AwarenessRepository {
   getAwarenessYearById(id: string): Promise<AwarenessYear>
   getAwarenessByYearId(yearId: string, search?: string, page?: number, pageSize?: number): Promise<AwarenessResponse>
   getAwarenessById(id: string): Promise<Awareness>
+  getAwarenessByYearAndSlug(year: string, slug: string): Promise<Awareness | null>
 }

--- a/core/services/awareness-service.ts
+++ b/core/services/awareness-service.ts
@@ -23,4 +23,8 @@ export class AwarenessService {
   async getAwarenessById(id: string): Promise<Awareness> {
     return this.awarenessRepository.getAwarenessById(id)
   }
+
+  async getAwarenessByYearAndSlug(year: string, slug: string): Promise<Awareness | null> {
+    return this.awarenessRepository.getAwarenessByYearAndSlug(year, slug)
+  }
 }

--- a/lib/security-procedures-utils.ts
+++ b/lib/security-procedures-utils.ts
@@ -1,9 +1,9 @@
 import { slugify } from "./utils"
 
 // Utility functions for security procedures slug handling
-export function createSecurityProcedureSlug(name: string): string {
-  if (!name) return ""
-  return slugify(name)
+export function createSecurityProcedureSlug(name: string, id?: string): string {
+  if (!name) return id || ""
+  return slugify(name, id)
 }
 
 // Function to find entity by slug from a list
@@ -16,7 +16,7 @@ export function findEntityBySlug<T extends { id: string; nameEn?: string; name?:
   return (
     entities.find((entity) => {
       const entityName = entity.nameEn || entity.name || ""
-      return createSecurityProcedureSlug(entityName) === slug
+      return createSecurityProcedureSlug(entityName, entity.id) === slug
     }) || null
   )
 }
@@ -49,31 +49,31 @@ export function generateSecurityProcedureUrls(
   if (!standard) return { base }
 
   const standardName = standard.nameEn || standard.name || ""
-  const standardSlug = createSecurityProcedureSlug(standardName)
+  const standardSlug = createSecurityProcedureSlug(standardName, standard.id)
   const standardUrl = `${base}/${standardSlug}`
 
   if (!control) return { base, standardUrl }
 
   const controlName = control.nameEn || control.name || ""
-  const controlSlug = createSecurityProcedureSlug(controlName)
+  const controlSlug = createSecurityProcedureSlug(controlName, control.id)
   const controlUrl = `${standardUrl}/${controlSlug}`
 
   if (!safeguard) return { base, standardUrl, controlUrl }
 
   const safeguardName = safeguard.nameEn || safeguard.name || ""
-  const safeguardSlug = createSecurityProcedureSlug(safeguardName)
+  const safeguardSlug = createSecurityProcedureSlug(safeguardName, safeguard.id)
   const safeguardUrl = `${controlUrl}/${safeguardSlug}`
 
   if (!technique) return { base, standardUrl, controlUrl, safeguardUrl }
 
   const techniqueName = technique.nameEn || technique.name || ""
-  const techniqueSlug = createSecurityProcedureSlug(techniqueName)
+  const techniqueSlug = createSecurityProcedureSlug(techniqueName, technique.id)
   const techniqueUrl = `${safeguardUrl}/${techniqueSlug}`
 
   if (!implementation) return { base, standardUrl, controlUrl, safeguardUrl, techniqueUrl }
 
   const implementationName = implementation.nameEn || implementation.name || ""
-  const implementationSlug = createSecurityProcedureSlug(implementationName)
+  const implementationSlug = createSecurityProcedureSlug(implementationName, implementation.id)
   const implementationUrl = `${techniqueUrl}/${implementationSlug}`
 
   return { base, standardUrl, controlUrl, safeguardUrl, techniqueUrl, implementationUrl }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,12 +5,12 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function slugify(text: string): string {
+export function slugify(text: string | null | undefined, fallback?: string): string {
   if (!text || text.trim() === "") {
-    return ""
+    return fallback || ""
   }
 
-  return (
+  const slug =
     text
       .toString()
       .normalize("NFD") // Normalize Unicode
@@ -23,23 +23,19 @@ export function slugify(text: string): string {
       .replace(/--+/g, "-") // Replace multiple hyphens with single hyphen
       .replace(/^-+|-+$/g, "") // Remove leading/trailing hyphens
       .substring(0, 50)
-  ) // Limit length
+
+  return slug || fallback || ""
 }
 
 // Alternative slugify for Arabic - creates ID-based slugs
 export function createNewsSlug(news: any, language: string): string {
   const title = language === "ar" ? news.title || news.titleEn : news.titleEn || news.title
 
-  if (!title || title.trim() === "") {
-    return news.id || "news-item"
-  }
-
-  // For Arabic text or if slugify fails, use ID + partial title
-  const slugifiedTitle = slugify(title)
+  const slugifiedTitle = slugify(title, news.id || "news-item")
 
   if (slugifiedTitle.length < 3) {
     // If slug is too short (Arabic text didn't convert well), use ID-based slug
-    return `${news.id.substring(0, 8)}-${Date.now()}`
+    return news.id || "news-item"
   }
 
   return slugifiedTitle


### PR DESCRIPTION
## Summary
- use item id as slug fallback when English title is empty
- update news components and repositories to use id-based slugs
- extend slugify helper with fallback id support

## Testing
- `pnpm lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689cf8d0005c832e93f1abf5d7026b21